### PR TITLE
Add profile side menu in twt page

### DIFF
--- a/src/main/java/com/devtwt/app/bean/UserBean.java
+++ b/src/main/java/com/devtwt/app/bean/UserBean.java
@@ -25,7 +25,14 @@ public class UserBean implements Serializable {
 	//セレクトボックスで選択された値が設定される
 	private String slctRoleName = "";
 	private String slctRoleId = "";
+	List<GroupBean> groupList = new ArrayList<GroupBean>();
 	
+	public List<GroupBean> getGroupList() {
+		return groupList;
+	}
+	public void setGroupList(List<GroupBean> groupList) {
+		this.groupList = groupList;
+	}
 	public String getSlctRoleId() {
 		return slctRoleId;
 	}
@@ -113,7 +120,8 @@ public class UserBean implements Serializable {
 				+ ", createDate=" + createDate + ", updateId=" + updateId
 				+ ", updateDate=" + updateDate + ", deleteFlag=" + deleteFlag
 				+ ", roleList=" + roleList + ", slctRoleName=" + slctRoleName
-				+ ", slctRoleId=" + slctRoleId + "]";
+				+ ", slctRoleId=" + slctRoleId + ", groupList=" + groupList
+				+ "]";
 	}
 
 }

--- a/src/main/java/com/devtwt/app/command/GetBelongingGroupsCommand.java
+++ b/src/main/java/com/devtwt/app/command/GetBelongingGroupsCommand.java
@@ -1,0 +1,11 @@
+package com.devtwt.app.command;
+
+import com.devtwt.app.bean.RootBean;
+
+public interface GetBelongingGroupsCommand {
+	
+	void preProc(RootBean bean);
+	void exec(String userName);
+	RootBean postProc();
+
+}

--- a/src/main/java/com/devtwt/app/command/GetBelongingGroupsCommandImpl.java
+++ b/src/main/java/com/devtwt/app/command/GetBelongingGroupsCommandImpl.java
@@ -1,0 +1,51 @@
+package com.devtwt.app.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.devtwt.app.bean.GroupBean;
+import com.devtwt.app.bean.RootBean;
+import com.devtwt.app.dao.GroupDao;
+import com.devtwt.app.dao.UserMasterDao;
+
+@Component
+public class GetBelongingGroupsCommandImpl implements GetBelongingGroupsCommand{
+	
+	@Autowired
+	private RootBean bean;
+	@Autowired
+	private GroupDao groupDao;
+	@Autowired
+	private UserMasterDao userDao;
+	
+	String memberId;
+	List<GroupBean> groupList;
+
+	@Override
+	public void preProc(RootBean bean) {
+		// TODO Auto-generated method stub
+		this.bean = bean;
+	}
+
+	@Override
+	public void exec(String userName) {
+		// TODO Auto-generated method stub
+		
+		//ログインしたアカウントのIDから、所属しているグループを全て取得
+		memberId = userDao.getUserId(userName);
+		groupList = groupDao.selectGroupListBymemberId(memberId);
+		bean.getUser().setGroupList(groupList);
+	}
+
+	@Override
+	public RootBean postProc() {
+		// TODO Auto-generated method stub
+		return bean;
+	}
+	
+	
+
+}

--- a/src/main/java/com/devtwt/app/dao/GroupDao.java
+++ b/src/main/java/com/devtwt/app/dao/GroupDao.java
@@ -1,9 +1,12 @@
 package com.devtwt.app.dao;
 
+import java.util.List;
+
 import com.devtwt.app.bean.GroupBean;
 
 public interface GroupDao {
 	
 	public GroupBean selectGroupById(String groupId);
 	public void insertData(GroupBean group);
+	public List<GroupBean> selectGroupListBymemberId(String memberId);
 }

--- a/src/main/java/com/devtwt/app/dao/GroupDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/GroupDaoImpl.java
@@ -2,6 +2,7 @@ package com.devtwt.app.dao;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -70,5 +71,31 @@ public class GroupDaoImpl implements GroupDao {
                 		, group.getMemberId(), group.getCreateId(), group.getCreateDate()
                 		, group.getUpdateId(), group.getUpdateDate());
 	}
+
+	@Override
+	public List<GroupBean> selectGroupListBymemberId(String memberId) {
+		// TODO Auto-generated method stub
+		
+		List<GroupBean> groupList = jdbcTemplate.query(
+				"SELECT * FROM COMMUNITY WHERE MEMBER_ID = ?"
+				, new RowMapper<GroupBean>() {
+					public GroupBean mapRow(ResultSet rs, int rowNum) throws SQLException {
+						GroupBean groupBean = new GroupBean();
+						groupBean.setGroupId(rs.getString("COMMUNITY_ID"));
+						groupBean.setGroupName(rs.getString("COMMUNITY_NAME"));
+						groupBean.setDevCategoryId(rs.getString("DEV_CATEGORY_COMMUNITY_ID"));
+						groupBean.setMemberId(rs.getString("MEMBER_ID"));
+						groupBean.setCreateId(rs.getString("CREATE_ID"));
+						groupBean.setCreateDate(rs.getString("CREATE_DATE"));
+						groupBean.setUpdateId(rs.getString("UPDATE_ID"));
+						groupBean.setUpdateDate(rs.getString("UPDATE_DATE"));
+						return groupBean;
+					}}
+				, memberId);
+		
+		return groupList;
+	}
+	
+	
 
 }

--- a/src/main/webapp/WEB-INF/views/twt.jsp
+++ b/src/main/webapp/WEB-INF/views/twt.jsp
@@ -86,91 +86,120 @@ body { margin-top:30px; }
        </div> 
    </div>
    
+   <div class="container">
+   　　　<div class="row">
+	
+	<!-- プロフィールサイドバー -->
+	<div class="col-md-2">
+		<div class="media">
+			<img src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
+					class="media-object" width="120" height="120">
+			<div class="profile-usertitle">
+				<div class="profile-usertitle-name" style="text-align:center">
+					<a href="#"><sec:authentication property="principal.username" /></a>
+				</div>
+			</div>
+			<div class="profile-usermenu">
+			   <h4>Groups</h4>
+				<ul class="nav">
+					<c:if test="${not empty rootData.user.groupList}">
+						<c:forEach items="${rootData.user.groupList}" var="list" >
+							<li><a href="#"><c:out value="${list.groupName}"/></a></li>
+						</c:forEach>
+				    </c:if>
+				</ul>
+			</div>
+		</div>
+	</div>
+	
+   
 	<!-- コメント投稿フォーム -->
-	<div class="container main-content">
-		<table class="table table-hover" id="board">
-			<thead>
-				<tr>
-					<td colspan="2">
- 						<form:form id="postForm" modelAttribute="rootData" action="${pageContext.request.contextPath}/twt/json" >
-						    <div class="form-group">
-							    <form:textarea class="form-control" rows="5" id="postContents" path="momo.momo_contents"></form:textarea>
-								    <div align="right">
-									    <button id="post" class="btn btn-primary">send message!</button>
-								    </div>
-							</div>
-						</form:form>
-					</td>
-				</tr>
-			</thead>
-			<tbody>
-				<!-- ここに投稿コメントを表示 -->
-				<tr id="dummy">
-					<c:if test="${not empty rootData.momoList}">
-						<c:forEach items="${rootData.momoList}" var="list" begin="${start}" end="${end}">
-							<tr style="height:80">
-								<td class="momoComment">
-									<div class="media">
-										<a class="pull-left" href="#">
-										<img class="media-object" src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
-												class="img-rounded" width="80" height="80"/>
-										</a>
-										<div class="media-body">
-											 <input type="hidden" class="hiddenId" value="${list.momoNum}"/>
-											 <c:out value="${list.createName}"/>
-											 <p class="text-left">
-											 	<c:out value="${list.momo_contents}"/>
-											 </p>
-											 <p class="text-right">
-											 	<small><c:out value="${list.create_date}"/></small>
-											 </p>
-											 <p class="text-right">
-											 	<small>
-											 	    <c:if test="${list.childCount == -1}" var="flg" />
-											 	    <c:if test="${flg}">
-											 			<a class="reply-link" >コメントする</a>
-											 		</c:if>
-											 		<c:if test="${!flg}">
-											 			<c:forEach items="${list.childList}" var="list_child" begin="0" end="${list.childCount}">
-											 				 <div class="replyComment">
-																<div class="media">
-																	<a class="pull-left" href="#">
-																		<img class="media-object" src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
-																				class="img-rounded" width="80" height="80"/>
-																	</a>
-																	<div class="media-body">
-																		<p class="text-left">
-																			 <c:out value="${list_child.createName}"/>
-																		</p>
-																		<p class="text-left">
-																			<c:out value="${list_child.return_contents}"/>
-																		</p>
-																		 <p class="text-right">
-																			<small><c:out value="${list_child.create_date}"/></small>
-																		</p>
+		<div class="col-md-8">
+			<table class="table table-hover" id="board">
+				<thead>
+					<tr>
+						<td colspan="2">
+	 						<form:form id="postForm" modelAttribute="rootData" action="${pageContext.request.contextPath}/twt/json" >
+							    <div class="form-group">
+								    <form:textarea class="form-control" rows="5" id="postContents" path="momo.momo_contents"></form:textarea>
+									    <div align="right">
+										    <button id="post" class="btn btn-primary">send message!</button>
+									    </div>
+								</div>
+							</form:form>
+						</td>
+					</tr>
+				</thead>
+				<tbody>
+					<!-- ここに投稿コメントを表示 -->
+					<tr id="dummy">
+						<c:if test="${not empty rootData.momoList}">
+							<c:forEach items="${rootData.momoList}" var="list" begin="${start}" end="${end}">
+								<tr style="height:80">
+									<td class="momoComment">
+										<div class="media">
+											<a class="pull-left" href="#">
+											<img class="media-object" src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
+													class="img-rounded" width="80" height="80"/>
+											</a>
+											<div class="media-body">
+												 <input type="hidden" class="hiddenId" value="${list.momoNum}"/>
+												 <c:out value="${list.createName}"/>
+												 <p class="text-left">
+												 	<c:out value="${list.momo_contents}"/>
+												 </p>
+												 <p class="text-right">
+												 	<small><c:out value="${list.create_date}"/></small>
+												 </p>
+												 <p class="text-right">
+												 	<small>
+												 	    <c:if test="${list.childCount == -1}" var="flg" />
+												 	    <c:if test="${flg}">
+												 			<a class="reply-link" >コメントする</a>
+												 		</c:if>
+												 		<c:if test="${!flg}">
+												 			<c:forEach items="${list.childList}" var="list_child" begin="0" end="${list.childCount}">
+												 				 <div class="replyComment">
+																	<div class="media">
+																		<a class="pull-left" href="#">
+																			<img class="media-object" src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
+																					class="img-rounded" width="80" height="80"/>
+																		</a>
+																		<div class="media-body">
+																			<p class="text-left">
+																				 <c:out value="${list_child.createName}"/>
+																			</p>
+																			<p class="text-left">
+																				<c:out value="${list_child.return_contents}"/>
+																			</p>
+																			 <p class="text-right">
+																				<small><c:out value="${list_child.create_date}"/></small>
+																			</p>
+																		</div>
+																	</div>
+															        </div>
+															        <input type="hidden" class="hiddenId" value="${list_child.momo_momo_num}"/>
+												 			</c:forEach>
+												 				<div name="replyForm" class="replyForm">		
+																	<textarea name="replyContent" class="form-control" rows="5"></textarea>
+																	<div align="right">
+																		<button name="replyButton" class="btn btn-primary">send message!</button>
 																	</div>
 																</div>
-														        </div>
-														        <input type="hidden" class="hiddenId" value="${list_child.momo_momo_num}"/>
-											 			</c:forEach>
-											 				<div name="replyForm" class="replyForm">		
-																<textarea name="replyContent" class="form-control" rows="5"></textarea>
-																<div align="right">
-																	<button name="replyButton" class="btn btn-primary">send message!</button>
-																</div>
-															</div>
-											 		</c:if>
-											 	</small>
-											 </p>
-									     </div>
-									 </div>
-								</td>
-							</tr>
-						</c:forEach>
-					</c:if>
-				</tr>
-			</tbody>
-		</table>		
+												 		</c:if>
+												 	</small>
+												 </p>
+										     </div>
+										 </div>
+									</td>
+								</tr>
+							</c:forEach>
+						</c:if>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>	
 	</div>
 	<!-- 返信コメントの描画に使うテンプレート -->
 	<script type="text/html" id="tmplReplyComment">
@@ -207,28 +236,28 @@ body { margin-top:30px; }
 	<!-- 投稿コメントの描画に使うテンプレート -->
 	<script type="text/html" id="tmplComment">
 		<tr style="height:80">
-								<td class="momoComment">
-									<div class="media">
-										<a class="pull-left" href="#">
-										<img class="media-object" src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
-												class="img-rounded" width="80" height="80"/>
-										</a>
-										<div class="media-body">
-											 <input type="hidden" class="hiddenId" value="{{momoNum}}"/>
-											 {{name}}
-											 <p class="text-left">
-											 	{{contents}}
-											 </p>
-											 <p class="text-right">
-											 	<small>{{time}}</small>
-											 </p>
-											 <p class="text-right">
-											 	<small><a class="reply-link" >コメントする</a></small>
-											 </p>
-									     </div>
-									 </div>
-								</td>
-							</tr>
+			<td class="momoComment">
+				<div class="media">
+					<a class="pull-left" href="#">
+						<img class="media-object" src="<c:url value='/resources/bootstrap-3.3.2-dist/profile.png'/>"
+								class="img-rounded" width="80" height="80"/>
+					</a>
+					<div class="media-body">
+						<input type="hidden" class="hiddenId" value="{{momoNum}}"/>
+							{{name}}
+						<p class="text-left">
+							{{contents}}
+						</p>
+						<p class="text-right">
+							<small>{{time}}</small>
+						</p>
+						<p class="text-right">
+							<small><a class="reply-link" >コメントする</a></small>
+						</p>
+					</div>
+				</div>
+			</td>
+		</tr>
 	</script>
 	<!-- ******** js ******** -->
 	<spring:url var="twtJs" value="/resources/js/twt.js" />


### PR DESCRIPTION
・コメント投稿画面にログインアカウントの情報を表示する
　サイドメニューを追加しました。
・サイトメニューには、ログインアカウントが所属しているグループが全て表示されます。
・コーディング規則に則っていない状態です（リファクタリングしてません)。　
　後で修正予定。
・サイドメニューに表示されているグループ名をクリックすることにより、コメントがクリック
　したグループのものに切り替わるように実装する予定です。
