### PR TITLE
テーブルの主キーをAUTO_INCREMENTにしました。

### DIFF
--- a/src/main/java/com/devtwt/app/dao/GroupCreateDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/GroupCreateDaoImpl.java
@@ -86,23 +86,7 @@ public class GroupCreateDaoImpl implements GroupCreateDao {
 
 	@Override
 	public void insertData(RootBean bean, String userName) {
-		// TODO Auto-generated method stub
-		String communityId;
-    	int tmp,cnt;
-    	
-    	cnt = jdbcTemplate.queryForInt("SELECT COUNT(*) FROM COMMUNITY");
-    	
-    	//テーブルCOMMUNITYのデータが0件の場合
-    	if(cnt == 0) {
-    		communityId = "0";
-    	} else {
-    		communityId = jdbcTemplate.queryForObject("SELECT MAX(COMMUNITY_ID) FROM COMMUNITY", String.class);
-    	}
-        
-    	//COMMUNITY_IDをインクリメント
-    	tmp = Integer.parseInt(communityId);
-    	bean.getGroup().setGroupId(String.valueOf(++tmp));
-    	
+		
     	//Group作成者または、招待メンバの情報を設定
     	String memberId = jdbcTemplate.queryForObject("SELECT MEMBER_ID FROM USER_MASTER WHERE MEMBER_NAME = ?", String.class, userName);
     	bean.getGroup().setCreateId(memberId);
@@ -111,9 +95,9 @@ public class GroupCreateDaoImpl implements GroupCreateDao {
     	
     	//Groupを新規作成
     	jdbcTemplate.update(
-                "INSERT INTO COMMUNITY (COMMUNITY_ID, COMMUNITY_NAME, DEV_CATEGORY_COMMUNITY_ID, MEMBER_ID"
-                			+ ", CREATE_ID, CREATE_DATE, UPDATE_ID, UPDATE_DATE) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-                , bean.getGroup().getGroupId(), bean.getGroup().getGroupName(), bean.getGroup().getSlctDevCateId()
+                "INSERT INTO COMMUNITY (COMMUNITY_NAME, DEV_CATEGORY_COMMUNITY_ID, MEMBER_ID"
+                			+ ", CREATE_ID, CREATE_DATE, UPDATE_ID, UPDATE_DATE) VALUES (?, ?, ?, ?, ?, ?, ?)"
+                , bean.getGroup().getGroupName(), bean.getGroup().getSlctDevCateId()
                 		, bean.getGroup().getMemberId(), bean.getGroup().getCreateId(), bean.getGroup().getCreateDate()
                 		, bean.getGroup().getUpdateId(), bean.getGroup().getUpdateDate());
     }

--- a/src/main/java/com/devtwt/app/dao/MomoDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/MomoDaoImpl.java
@@ -53,26 +53,9 @@ public class MomoDaoImpl implements MomoDao {
 	public void exec(RootBean bean, String userName) {
 		// TODO Auto-generated method stub
 		
-		String momoNum;
-    	int tmp,cnt;
     	String DATE_PATTERN ="yyyy-MM-dd HH:mm:ss";
-		
-        cnt = jdbcTemplate.queryForInt("SELECT COUNT(*) FROM MOMO");
     	
-    	//テーブルMOMOのデータが0件の場合
-    	if(cnt == 0) {
-    		momoNum = "0";
-    	} else {
-    		momoNum  = jdbcTemplate.queryForObject("SELECT MAX(MOMO_NUM) FROM MOMO", String.class);
-    	}
-    	
-    	//MOMO_NUMをインクリメント
-    	tmp = Integer.parseInt(momoNum);
-    	bean.getMomo().setMomoNum(String.valueOf(++tmp));
-    	
-    	//AllowNullがfalseのカラムに値を設定
-    	bean.getMomo().setStream_stream_num("1");
-    	
+    	//ログインアカウント名から、ユーザIDを取得し、beanの各プロパティにセット
     	String memberId = jdbcTemplate.queryForObject("SELECT MEMBER_ID FROM USER_MASTER WHERE MEMBER_NAME = ?", String.class, userName);
 		bean.getMomo().setUser_master_member_id(memberId);
 		bean.getMomo().setCreate_id(memberId);
@@ -87,9 +70,9 @@ public class MomoDaoImpl implements MomoDao {
 		
     	//MOMOをテーブルにINSERT
 		jdbcTemplate.update(
-                "INSERT INTO MOMO (MOMO_NUM, STREAM_STEREAM_NUM, PHASE, MOMO_CONTENTS, CREATE_ID"
-                + ", CREATE_DATE, UPDATE_ID, UPDATE_DATE, USER_MASTER_MEMBER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
-                , bean.getMomo().getMomoNum(), bean.getMomo().getStream_stream_num(), bean.getMomo().getPhase(),
+                "INSERT INTO MOMO (STREAM_STEREAM_NUM, PHASE, MOMO_CONTENTS, CREATE_ID"
+                + ", CREATE_DATE, UPDATE_ID, UPDATE_DATE, USER_MASTER_MEMBER_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                , bean.getMomo().getStream_stream_num(), bean.getMomo().getPhase(),
                 bean.getMomo().getMomo_contents(), bean.getMomo().getCreate_id(), bean.getMomo().getCreate_date(),
                 bean.getMomo().getUpdate_id(), bean.getMomo().getUpdate_date(), bean.getMomo().getUser_master_member_id());
 		

--- a/src/main/java/com/devtwt/app/dao/UserMasterDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/UserMasterDaoImpl.java
@@ -55,34 +55,11 @@ public class UserMasterDaoImpl implements UserMasterDao {
 
 	public void exec(RootBean bean) {
     	
-    	String memberId;
-    	int tmp,cnt;
-    	
-    	cnt = jdbcTemplate.queryForInt("SELECT COUNT(*) FROM USER_MASTER");
-    	
-    	//テーブルUSER_MASTERのデータが0件の場合
-    	if(cnt == 0) {
-    		memberId = "0";
-    	} else {
-    		memberId = jdbcTemplate.queryForObject("SELECT MAX(MEMBER_ID) FROM USER_MASTER", String.class);
-    	}
-        
-    	//USER_IDをインクリメント
-    	tmp = Integer.parseInt(memberId);
-    	bean.getUser().setUserId(String.valueOf(++tmp));
-    	
-    	cnt = jdbcTemplate.queryForInt("SELECT COUNT(*) FROM ROLE_MASTER WHERE ROLE_ID = 1");
-    	
-    	//テーブルROLE_MASTERにROLE_ID:1のデータがない場合
-    	if(cnt == 0){
-    		jdbcTemplate.update("INSERT INTO ROLE_MASTER (ROLE_ID) VALUES(1)");
-    	}
-    	
     	//ユーザを新規作成
-    	//Spring Securityとの関連で一時的に有効なアカウントのDELETE_FLAGを1に設定(無効なアカウントのDELETE_FLAGは、0)。
+    	//Spring Securityとの関連で一時的に有効なアカウントのDELETE_FLAGを1に設定(無効なアカウントのDELETE_FLAGは、0)
     	jdbcTemplate.update(
-                "INSERT INTO USER_MASTER (MEMBER_ID, MEMBER_NAME, PASSWORD, ROLE_MASTER_ROLE_ID, DELETE_FLAG) VALUES (?, ?, ?, ?, ?)"
-                , bean.getUser().getUserId(), bean.getUser().getUserName(),bean.getUser().getUserPassword(),bean.getUser().getSlctRoleId(), "1");
+                "INSERT INTO USER_MASTER (MEMBER_NAME, PASSWORD, ROLE_MASTER_ROLE_ID, DELETE_FLAG) VALUES (?, ?, ?, ?)"
+                , bean.getUser().getUserName(),bean.getUser().getUserPassword(),bean.getUser().getSlctRoleId(), "1");
     }
 
 	@Override


### PR DESCRIPTION
・主キー重複エラーが頻発していたため、'COMMUNITY'、'MOMO'、'USER_MASTER'の3テーブルの主キーをAUTO_INCREMENTに変更しました。
・上記テーブル定義の変更に伴い、Daoに修正を加えました。
・テーブル定義変更済みのデータベースファイルについては、別途メールで共有します
