### PR TITLE
【障害改修】投稿直後のコメント(MOMO)に対して返信しても、返信コメントが保存されない

### DIFF
--- a/src/main/java/com/devtwt/app/command/impl/TwtPostCommandImpl.java
+++ b/src/main/java/com/devtwt/app/command/impl/TwtPostCommandImpl.java
@@ -17,6 +17,8 @@ public class TwtPostCommandImpl implements TwtPostCommand {
 	RootBean bean;
 	@Autowired
 	UserMasterDao userDao;
+	int tmp;
+	String momoNum;
 
 	@Override
 	public void preProc(RootBean bean) {
@@ -27,6 +29,11 @@ public class TwtPostCommandImpl implements TwtPostCommand {
 	public void exec(String userName, String groupId) {
 		bean.getMomo().setGroupId(groupId);
 		momo.exec(bean, userName);
+		
+		//ここで追加したMOMOのIDを取得し、Beanにセット
+		tmp = momo.selectMaxMomoNum();
+		momoNum = Integer.toString(tmp);
+		bean.getMomo().setMomoNum(momoNum);
 		
 		//画面に表示するため、投稿者名をbeanにセット
 		bean.getMomo().setCreateName(userDao.getUserName(bean.getMomo().getCreate_id()));

--- a/src/main/java/com/devtwt/app/dao/MomoDao.java
+++ b/src/main/java/com/devtwt/app/dao/MomoDao.java
@@ -9,5 +9,6 @@ public interface MomoDao {
 	
 	public void exec(RootBean bean, String userName);
 	public List<MomoBean> getAllData(String groupId);
+	public int selectMaxMomoNum();
 
 }

--- a/src/main/java/com/devtwt/app/dao/impl/MomoDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/impl/MomoDaoImpl.java
@@ -79,5 +79,12 @@ public class MomoDaoImpl implements MomoDao {
                 bean.getMomo().getUpdate_id(), bean.getMomo().getUpdate_date(), bean.getMomo().getUser_master_member_id(),
                 bean.getMomo().getGroupId());
 	}
+	
+	public int selectMaxMomoNum() {
+		
+		int momoNum = jdbcTemplate.queryForObject("SELECT MAX(MOMO_NUM) FROM MOMO", Integer.class);
+		return momoNum;
+		
+	}
 
 }


### PR DESCRIPTION
・DBのIDをオートインクリメントにする改修により発生した障害
・MOMOのインサート後に、インサートしたMOMOのIDを取得していなかったため、発生
・インサート直後に、MOMOのIDを取得するように改修した
