### PR TITLE
【改善】Communityテーブルのオートインクリメント機能が使用されていない

### DIFF
--- a/src/main/java/com/devtwt/app/command/impl/TwtPostCommandImpl.java
+++ b/src/main/java/com/devtwt/app/command/impl/TwtPostCommandImpl.java
@@ -17,6 +17,8 @@ public class TwtPostCommandImpl implements TwtPostCommand {
 	RootBean bean;
 	@Autowired
 	UserMasterDao userDao;
+	int tmp;
+	String momoNum;
 
 	@Override
 	public void preProc(RootBean bean) {
@@ -27,6 +29,11 @@ public class TwtPostCommandImpl implements TwtPostCommand {
 	public void exec(String userName, String groupId) {
 		bean.getMomo().setGroupId(groupId);
 		momo.exec(bean, userName);
+		
+		//ここで追加したMOMOのIDを取得し、Beanにセット
+		tmp = momo.selectMaxMomoNum();
+		momoNum = Integer.toString(tmp);
+		bean.getMomo().setMomoNum(momoNum);
 		
 		//画面に表示するため、投稿者名をbeanにセット
 		bean.getMomo().setCreateName(userDao.getUserName(bean.getMomo().getCreate_id()));

--- a/src/main/java/com/devtwt/app/dao/MomoDao.java
+++ b/src/main/java/com/devtwt/app/dao/MomoDao.java
@@ -9,5 +9,6 @@ public interface MomoDao {
 	
 	public void exec(RootBean bean, String userName);
 	public List<MomoBean> getAllData(String groupId);
+	public int selectMaxMomoNum();
 
 }

--- a/src/main/java/com/devtwt/app/dao/impl/GroupDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/impl/GroupDaoImpl.java
@@ -47,28 +47,12 @@ public class GroupDaoImpl implements GroupDao {
 
 	@Override
 	public void insertData(GroupBean group) {
-		// TODO Auto-generated method stub
-		String communityId;
-    	int tmp,cnt;
-    	
-    	cnt = jdbcTemplate.queryForInt("SELECT COUNT(*) FROM COMMUNITY");
-    	
-    	//テーブルCOMMUNITYのデータが0件の場合
-    	if(cnt == 0) {
-    		communityId = "0";
-    	} else {
-    		communityId = jdbcTemplate.queryForObject("SELECT MAX(COMMUNITY_ID) FROM COMMUNITY", String.class);
-    	}
-        
-    	//COMMUNITY_IDをインクリメント
-    	tmp = Integer.parseInt(communityId);
-    	group.setGroupId(String.valueOf(++tmp));
-    	
+		
     	//Groupを新規作成
     	jdbcTemplate.update(
-                "INSERT INTO COMMUNITY (COMMUNITY_ID, COMMUNITY_NAME, DEV_CATEGORY_COMMUNITY_ID, MEMBER_ID"
-                			+ ", CREATE_ID, CREATE_DATE, UPDATE_ID, UPDATE_DATE) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-                , group.getGroupId(), group.getGroupName(), group.getDevCategoryId()
+                "INSERT INTO COMMUNITY (COMMUNITY_NAME, DEV_CATEGORY_COMMUNITY_ID, MEMBER_ID"
+                			+ ", CREATE_ID, CREATE_DATE, UPDATE_ID, UPDATE_DATE) VALUES (?, ?, ?, ?, ?, ?, ?)"
+                , group.getGroupName(), group.getDevCategoryId()
                 		, group.getMemberId(), group.getCreateId(), group.getCreateDate()
                 		, group.getUpdateId(), group.getUpdateDate());
 	}

--- a/src/main/java/com/devtwt/app/dao/impl/MomoDaoImpl.java
+++ b/src/main/java/com/devtwt/app/dao/impl/MomoDaoImpl.java
@@ -79,5 +79,12 @@ public class MomoDaoImpl implements MomoDao {
                 bean.getMomo().getUpdate_id(), bean.getMomo().getUpdate_date(), bean.getMomo().getUser_master_member_id(),
                 bean.getMomo().getGroupId());
 	}
+	
+	public int selectMaxMomoNum() {
+		
+		int momoNum = jdbcTemplate.queryForObject("SELECT MAX(MOMO_NUM) FROM MOMO", Integer.class);
+		return momoNum;
+		
+	}
 
 }


### PR DESCRIPTION
・テーブル定義は変更していない。
・Groupの新規作成の際に、オートインクリメント機能を使用せずに、javaソースでIDをインクリメントしていたので、改修した。現在は、Groupの新規作成の際にも、オートインクリメント機能を使用している。
